### PR TITLE
Fix baseurl and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-url: ""
-baseurl: ""
+url: "https://sssped.github.io"
+baseurl: "/El-becatorio"
 
 # Site settings
 title: El Becatorio

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     <body id="page-top" class="index">
 
     {% include header.html %}
+    {{ content }}
     {% include services.html %}
     {% include portfolio_grid.html %}
     {% include about.html %}


### PR DESCRIPTION
## Summary
- configure GitHub Pages base URL
- show markdown content in `default.html`
- ignore generated site output

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684aedfbd58c8321bb1ed034528fc66f