### PR TITLE
Use agency theme for homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,10 @@
-url: ""
-baseurl: ""
+url: "https://sssped.github.io"
+baseurl: "/El-becatorio"
+remote_theme: raviriley/agency-jekyll-theme
+
+# Needed for remote themes when building locally
+plugins:
+  - jekyll-remote-theme
 
 # Site settings
 title: El Becatorio

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,9 +47,4 @@
             </div>
         </div>
     </header>
-<!--
-        {% for page in site.pages %}
-          {% if page.title %}<a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>{% endif %}
-        {% endfor %}
- -->
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     <body id="page-top" class="index">
 
     {% include header.html %}
+    {{ content }}
     {% include services.html %}
     {% include portfolio_grid.html %}
     {% include about.html %}

--- a/index.md
+++ b/index.md
@@ -1,10 +1,11 @@
 ---
-layout: default
+layout: home
 title: "Inicio"
 ---
 
-Bienvenido a **El Becatorio**. Usa el menú superior para navegar por las becas y noticias.
+Bienvenido a **El Becatorio**, tu fuente de información sobre oportunidades de becas en Guatemala. Visita nuestras secciones para conocer noticias y convocatorias vigentes.
 
 ## Contacto
 
 Si deseas colaborar con "El Becatorio" o tienes alguna consulta, escríbenos a [info@becatorio.com](mailto:info@becatorio.com).
+


### PR DESCRIPTION
## Summary
- configure remote theme `raviriley/agency-jekyll-theme`
- switch home page to `layout: home`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684aedfbd58c8321bb1ed034528fc66f