### PR TITLE
Fix Jekyll build on GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source "https://rubygems.org"
 
 gem "webrick", "~> 1.7"
 gem "jekyll", "~> 4.3"
-gem "jekyll-environment-variables"

--- a/_config.yml
+++ b/_config.yml
@@ -35,8 +35,6 @@ defaults:
 sass:
   style: compressed # possible values: nested expanded compact compressed
 
-plugins:
-  - jekyll-environment-variables
 
 exclude:
   - Gemfile


### PR DESCRIPTION
## Summary
- remove `jekyll-environment-variables` plugin which isn't allowed on GitHub Pages

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68541aac11d48321b07192d6cf330679